### PR TITLE
allow custom clipping path to actors

### DIFF
--- a/src/math/bezier.js
+++ b/src/math/bezier.js
@@ -28,6 +28,24 @@
 		HANDLE_SIZE:	20,
 		drawHandles:	true,
 
+		/**
+         * Draw the curve control points.
+         * @param director {CAAT.Director}
+         * @param stroke   bool
+         */
+		draw : function(director, stroke) {
+			var canvas= director.crc;
+			canvas.moveTo( this.coordlist[0].x, this.coordlist[0].y );
+			canvas.lineTo( this.coordlist[1].x, this.coordlist[1].y );
+			if(stroke)
+				canvas.stroke();
+			if ( this.cubic ) {
+				canvas.moveTo( this.coordlist[2].x, this.coordlist[2].y );
+				canvas.lineTo( this.coordlist[3].x, this.coordlist[3].y );
+				if(stroke)
+					canvas.stroke();
+			}
+		},
         /**
          * Paint the curve control points.
          * @param director {CAAT.Director}
@@ -44,15 +62,8 @@
 			canvas.beginPath();
 			
 			canvas.strokeStyle='#a0a0a0';
-			canvas.moveTo( this.coordlist[0].x, this.coordlist[0].y );
-			canvas.lineTo( this.coordlist[1].x, this.coordlist[1].y );
-			canvas.stroke();
-			if ( this.cubic ) {
-				canvas.moveTo( this.coordlist[2].x, this.coordlist[2].y );
-				canvas.lineTo( this.coordlist[3].x, this.coordlist[3].y );
-				canvas.stroke();
-			} 
-			
+			this.draw(director, true);
+
             canvas.globalAlpha=0.5;
             for( var i=0; i<this.coordlist.length; i++ ) {
                 canvas.fillStyle='#7f7f00';
@@ -231,6 +242,18 @@
 
             return this;
 		},
+		/**
+         * Draws this curve.
+         *
+         * @param director {CAAT.Director}
+         */
+		draw : function( director ) {
+			if( this.cubic ) {
+				this.drawCubic(director);
+			} else {
+				this.drawCuadric(director);
+			}
+		},
         /**
          * Paint this curve.
          * @param director {CAAT.Director}
@@ -244,6 +267,26 @@
 			
 			CAAT.Bezier.superclass.paint.call(this,director);
 
+		},
+		/**
+         * Draws this cuadric Bezier curve.
+         *
+         * @param director {CAAT.Director}
+         */
+		drawCuadric : function( director ) {
+			var x1,y1;
+			x1 = this.coordlist[0].x;
+			y1 = this.coordlist[0].y;
+			
+			var canvas= director.crc;
+			
+			canvas.moveTo(x1,y1);
+
+			var point= new CAAT.Point();
+			for(var t=this.k;t<=1+this.k;t+=this.k){
+				this.solve(point,t);
+				canvas.lineTo(point.x, point.y );
+			}
 		},
         /**
          * Paint this quadric Bezier curve. Each time the curve is drawn it will be solved again from 0 to 1 with
@@ -272,6 +315,26 @@
 			canvas.stroke();
 			canvas.restore();
 		
+		},
+		/**
+         * Draws this cubic Bezier curve.
+         *
+         * @param director {CAAT.Director}
+         */
+		drawCubic : function( director ) {
+			var x1,y1;
+			x1 = this.coordlist[0].x;
+			y1 = this.coordlist[0].y;
+			
+			var canvas= director.crc;
+			
+			canvas.moveTo(x1,y1);
+			
+			var point= new CAAT.Point();
+			for(var t=this.k;t<=1+this.k;t+=this.k){
+				this.solve(point,t);
+				canvas.lineTo(point.x, point.y );
+			}
 		},
         /**
          * Paint this cubic Bezier curve. Each time the curve is drawn it will be solved again from 0 to 1 with

--- a/src/model/actor.js
+++ b/src/model/actor.js
@@ -1164,7 +1164,11 @@
 
             if ( this.clip ) {
                 ctx.beginPath();
-                ctx.rect(0,0,this.width,this.height);
+                if(this.clipPath) {
+					this.clipPath.draw(director);
+				} else {
+					ctx.rect(0,0,this.width,this.height);
+				}
                 ctx.clip();
             }
 
@@ -1323,6 +1327,16 @@
          */
         setClip : function( clip ) {
             this.clip= clip;
+            return this;
+        },
+		/**
+         * Set the clipping path for this Actor.
+         *
+         * @param path a CAAT.Path object
+         * @return this
+         */
+        setClipPath : function( path ) {
+            this.clipPath= path;
             return this;
         },
         /**

--- a/src/path/path.js
+++ b/src/path/path.js
@@ -205,6 +205,14 @@
 		finalPositionX : function() {
 			return this.finalPosition.x;
 		},
+		/**
+         * Draws this path segment on screen.
+         * @param director {CAAT.Director}
+         */
+		draw : function(director) {
+			var canvas= director.crc;
+			canvas.lineTo( this.finalPosition.x, this.finalPosition.y );
+		},
         /**
          * Draws this path segment on screen. Optionally it can draw handles for every control point, in
          * this case, start and ending path segment points.
@@ -220,7 +228,7 @@
             canvas.strokeStyle= this.color;
 			canvas.beginPath();
 			canvas.moveTo( this.initialPosition.x, this.initialPosition.y );
-			canvas.lineTo( this.finalPosition.x, this.finalPosition.y );
+			this.draw(director);
 			canvas.stroke();
 
             if ( bDrawHandles ) {
@@ -398,6 +406,13 @@
          */
 		getLength : function() {
 			return this.curve.getLength();
+		},
+		/**
+         * @inheritDoc
+         * @param director {CAAT.Director}
+         */
+		draw : function(director) {
+			this.curve.draw(director);
 		},
         /**
          * @inheritDoc
@@ -851,6 +866,15 @@
 			}
 			
 			return this.newPosition;
+		},
+		/**
+         * Draws this path segment on screen.
+         * @param director {CAAT.Director}
+         */
+		draw : function(director) {
+			for( var i=0; i<this.pathSegments.length; i++ ) {
+				this.pathSegments[i].draw(director);
+			}
 		},
         /**
          * Paints the path.


### PR DESCRIPTION
added setClipPath() function to CAAT.Actor to allow masking of actors and actor containers.

example usage:

``` javascript
var p= new CAAT.Path().
        beginPath(10,10).
        addCubicTo( 30,80, 90,30, 50,70 ).
        addQuadricTo( 80,60, 65,85).
        addLineTo( 10, 100).
        addLineTo( 25, 250).
        addLineTo( 99,40 ).
        closePath();

var c0= new CAAT.ActorContainer().
            setBounds( 10, 10, 90, 90 ).
            setClipPath(p).
            setClip(true);

var child0= new CAAT.Actor().
                setBounds( 10, 10, 180, 180 ).
                setFillStyle( 'red' );

var child1= new CAAT.ShapeActor().
                setShape( CAAT.ShapeActor.prototype.SHAPE_CIRCLE ).
                setFillStyle( 'green' ).
                setBounds( 20, 20, 140, 140 );

c0.addChild(child0);
c0.addChild(child1);
```
