### PR TITLE
TextActor skipping text part when background image is present

### DIFF
--- a/src/model/actor.js
+++ b/src/model/actor.js
@@ -2268,7 +2268,6 @@
 
             if ( this.backgroundImage ) {   // cached
                 CAAT.TextActor.superclass.paint.call(this, director, time );
-                return ;
             }
 
 			if ( null===this.text) {


### PR DESCRIPTION
You cannot both use a background image and a text overlaid on that.
