### PR TITLE
Flag to enabled/disable coordinate clamping

### DIFF
--- a/src/CAAT.js
+++ b/src/CAAT.js
@@ -8,7 +8,9 @@
 /**
  * @namespace
  */
-var CAAT= CAAT || {};
+var CAAT= CAAT || {
+	coordinateClampingEnabled: true	// flag indicating if actors coordinates are clamped to pixels.
+};
 
 /**
  * Common bind function. Allows to set an object's function as callback. Set for every function in the

--- a/src/math/affinetransform2D.js
+++ b/src/math/affinetransform2D.js
@@ -834,7 +834,10 @@
          */
         transformRenderingContextSet : function(ctx) {
             var m= this.matrix;
-            ctx.setTransform( m[0], m[3], m[1], m[4], m[2]>>0, m[5]>>0 );
+            if (CAAT.coordinateClampingEnabled)
+              ctx.setTransform( m[0], m[3], m[1], m[4], m[2]>>0, m[5]>>0 );
+            else
+              ctx.setTransform( m[0], m[3], m[1], m[4], m[2], m[5] );
             return this;
         },
 
@@ -844,7 +847,10 @@
          */
         transformRenderingContext : function(ctx) {
             var m= this.matrix;
-            ctx.transform( m[0], m[3], m[1], m[4], m[2]>>0, m[5]>>0 );
+					  if (CAAT.coordinateClampingEnabled)
+              ctx.transform( m[0], m[3], m[1], m[4], m[2]>>0, m[5]>>0 );
+            else
+              ctx.transform( m[0], m[3], m[1], m[4], m[2], m[5] );
             return this;
         }
 

--- a/src/model/director.js
+++ b/src/model/director.js
@@ -50,7 +50,7 @@
 
     CAAT.Director.prototype = {
 
-        debug:              false,  // flag indicating debug mode. It will draw affedted screen areas.
+        debug:              false,  // flag indicating debug mode. It will draw affected screen areas.
 
         onRenderStart:      null,
         onRenderEnd:        null,


### PR DESCRIPTION
Hi,

I don't know if it is the right thing to do, but I need to disable clamping for some platforms (on which performance is not a big deal) because of some scale effects that have lost their smoothness.
