### PR TITLE
Auto generate debug markup and optimize screen usage

### DIFF
--- a/src/model/debug.js
+++ b/src/model/debug.js
@@ -3,8 +3,8 @@
  *
  * Get realtime Debug information of CAAT's activity.
  * Set CAAT.DEBUG=1 before any CAAT.Director object creation.
- * This class expects a DOM node called 'caat-debug' being a container element (DIV) where
- * it will append itself. If this node is not present, it will append itself to the document's body.
+ * This class creates a DOM node called 'caat-debug' and associated styles
+ * The debug panel is minimized by default and shows short information. It can be expanded and minimized again by clicking on it
  *
  */
 
@@ -37,6 +37,122 @@
 
         SCALE:  60,
 
+        debugTpl: 
+            '<style type="text/css">'+
+                '#caat-debug {'+
+                    'z-index: 10000;'+
+                    'position:fixed; '+
+                    'bottom:0; '+
+                    'left:0; '+
+                    'width:100%;'+
+                    'background-color: rgba(0,0,0,0.8);'+
+                    'height: 120px;'+
+                    'margin-bottom: -104px;'+
+                '}'+
+                '#caat-debug.caat_debug_max {'+
+                    'margin-bottom: 0px;'+
+                '}'+
+                '.caat_debug_bullet {'+
+                    'display:inline-block;'+
+                    'background-color:#f00;'+
+                    'width:6px;'+
+                    'height:10px;'+
+                    'margin-left:4px;'+
+                    'margin-right:4px;'+
+                '}'+
+                '.caat_debug_description {'+
+                    'font-size:11px;'+
+                    'font-family: helvetica, arial;'+
+                    'color: #aaa;'+
+                    'display: inline-block;'+
+                '}'+
+                '.caat_debug_value {'+
+                    'font-size:11px;'+
+                    'font-family: helvetica, arial;'+
+                    'color: #fff;'+
+                    'width:25px;'+
+                    'text-align: right;'+
+                    'display: inline-block;'+
+                    'margin-right: .3em;'+
+                '}'+
+                '.caat_debug_menu {'+
+                    'font-family: helvetica, arial;'+
+                    'font-size: 12px;'+
+                    'font-weight: bold;'+
+                    'color: #888;'+
+                    'padding: 2px;'+
+                '}'+
+            '</style>'+
+            '<div id="caat-debug" onCLick="javascript: var debug = document.getElementById(\'caat-debug\');if (debug.className == \'\') {debug.className = \'caat_debug_max\'} else {debug.className = \'\'}">'+
+                '<div style="width:100%;">'+
+                    '<div class="caat_debug_menu">CAAT Performance '+
+                        '<span>'+
+                            '<span class="caat_debug_bullet" style="background-color:#f00;"></span>'+
+                            '<span class="caat_debug_value" id="textFPSShort">48</span>'+
+                        '</span>'+
+                        '<span>'+
+                            '<span class="caat_debug_bullet" style="background-color:#0f0;"></span>'+
+                            '<span class="caat_debug_value" id="textDrawTimeShort">5.46</span>'+
+                            '<span class="caat_debug_description">ms.</span>'+
+                        '</span>'+
+                        '<span>'+
+                            '<span class="caat_debug_bullet" style="background-color:#0f0;"></span>'+
+                            '<span class="caat_debug_value" id="textRAFTimeShort">20.76</span>'+
+                            '<span class="caat_debug_description">ms.</span>'+
+                        '</span>'+
+                        '<span>'+
+                            '<span class="caat_debug_bullet" style="background-color:#0ff;"></span>'+
+                            '<span class="caat_debug_value" id="textEntitiesTotalShort">41</span>'+
+                        '</span>'+
+                        '<span>'+
+                            '<span class="caat_debug_bullet" style="background-color:#0ff;"></span>'+
+                            '<span class="caat_debug_value" id="textEntitiesActiveShort">37</span>'+
+                        '</span>'+
+                        '<span>'+
+                            '<span class="caat_debug_bullet" style="background-color:#00f;"></span>'+
+                            '<span class="caat_debug_value" id="textDrawsShort">0</span>'+
+                        '</span>'+
+                    '</div>'+
+                '</div>'+
+                '<div id="caat-debug-performance">'+
+                    '<canvas id="caat-debug-canvas" height="60"></canvas>'+
+                    '<div>'+
+                        '<span>'+
+                            '<span class="caat_debug_bullet" style="background-color:#f00;"></span>'+
+                            '<span class="caat_debug_description">FPS: </span>'+
+                            '<span class="caat_debug_value" id="textFPS">48</span>'+
+                        '</span>'+
+                        '<span>'+
+                            '<span class="caat_debug_bullet" style="background-color:#0f0;"></span>'+
+                            '<span class="caat_debug_description">Draw Time: </span>'+
+                            '<span class="caat_debug_value" id="textDrawTime">5.46</span>'+
+                            '<span class="caat_debug_description">ms.</span>'+
+                        '</span>'+
+                        '<span>'+
+                            '<span class="caat_debug_bullet" style="background-color:#0f0;"></span>'+
+                            '<span class="caat_debug_description">RAF Time:</span>'+
+                            '<span class="caat_debug_value" id="textRAFTime">20.76</span>'+
+                            '<span class="caat_debug_description">ms.</span>'+
+                        '</span>'+
+                        '<span>'+
+                            '<span class="caat_debug_bullet" style="background-color:#0ff;"></span>'+
+                            '<span class="caat_debug_description">Entities Total: </span>'+
+                            '<span class="caat_debug_value" id="textEntitiesTotal">41</span>'+
+                        '</span>'+
+                        '<span>'+
+                            '<span class="caat_debug_bullet" style="background-color:#0ff;"></span>'+
+                            '<span class="caat_debug_description">Entities Active: </span>'+
+                            '<span class="caat_debug_value" id="textEntitiesActive">37</span>'+
+                        '</span>'+
+                        '<span>'+
+                            '<span class="caat_debug_bullet" style="background-color:#00f;"></span>'+
+                            '<span class="caat_debug_description">Draws: </span>'+
+                            '<span class="caat_debug_value" id="textDraws">0</span>'+
+                        '</span>'+
+                    '</div>'+
+                '</div>'+
+            '</div>',
+
         setScale : function(s) {
             this.scale= s;
             return this;
@@ -58,6 +174,14 @@
                 fpsMax: 0                                   // maximum measured framerate
             };
 
+            var debugContainer= document.getElementById('caat-debug');
+            if (!debugContainer) {
+                var wrap = document.createElement('div');
+                wrap.innerHTML=this.debugTpl;
+                document.body.appendChild(wrap);
+                console.log(wrap);
+            }
+
             this.canvas= document.getElementById('caat-debug-canvas');
             if ( null===this.canvas ) {
                 this.canDebug= false;
@@ -68,7 +192,7 @@
             this.canvas.height=h;
             this.ctx= this.canvas.getContext('2d');
 
-            this.ctx.fillStyle= 'black';
+            this.ctx.fillStyle= 'rgba(0,0,0,0.5)';
             this.ctx.fillRect(0,0,this.width,this.height);
 
             this.textFPS= document.getElementById("textFPS");
@@ -78,16 +202,19 @@
             this.textEntitiesActive= document.getElementById("textEntitiesActive");
             this.textDraws= document.getElementById("textDraws");
 
+            this.textFPSShort= document.getElementById("textFPSShort");
+            this.textDrawTimeShort= document.getElementById("textDrawTimeShort");
+            this.textRAFTimeShort= document.getElementById("textRAFTimeShort");
+            this.textEntitiesTotalShort= document.getElementById("textEntitiesTotalShort");
+            this.textEntitiesActiveShort= document.getElementById("textEntitiesActiveShort");
+            this.textDrawsShort= document.getElementById("textDrawsShort");
+
             this.canDebug= true;
 
             return this;
         },
 
         debugInfo : function( statistics ) {
-            if (!this.canDebug ) {
-                return;
-            }
-
             this.statistics= statistics;
 
             this.frameTimeAcc+= CAAT.FRAME_TIME;
@@ -100,15 +227,15 @@
                 this.framerate.fpsMin = this.framerate.frames > 0 ? Math.min( this.framerate.fpsMin, this.framerate.fps ) : this.framerate.fpsMin;
                 this.framerate.fpsMax = Math.max( this.framerate.fpsMax, this.framerate.fps );
 
-                this.textFPS.innerHTML= this.framerate.fps;
+                this.textFPS.innerHTML= this.textFPSShort.innerHTML= this.framerate.fps;
 
                 var value= ((this.frameTimeAcc*100/this.framerate.frames)|0)/100;
                 this.frameTimeAcc=0;
-                this.textDrawTime.innerHTML= value;
+                this.textDrawTime.innerHTML= this.textDrawTimeShort.innerHTML= value;
 
                 var value2= ((this.frameRAFAcc*100/this.framerate.frames)|0)/100;
                 this.frameRAFAcc=0;
-                this.textRAFTime.innerHTML= value2;
+                this.textRAFTime.innerHTML= this.textRAFTimeShort.innerHTML= value2;
 
                 this.framerate.timeLastRefresh = CAAT.RAF;
                 this.framerate.frames = 0;
@@ -116,9 +243,9 @@
                 this.paint(value2);
             }
 
-            this.textEntitiesTotal.innerHTML= this.statistics.size_total;
-            this.textEntitiesActive.innerHTML= this.statistics.size_active;
-            this.textDraws.innerHTML= this.statistics.draws;
+            this.textEntitiesTotal.innerHTML= this.textEntitiesTotalShort.innerHTML= this.statistics.size_total;
+            this.textEntitiesActive.innerHTML= this.textEntitiesActiveShort.innerHTML= this.statistics.size_active;
+            this.textDraws.innerHTML= this.textDrawsShort.innerHTML= this.statistics.draws;
         },
 
         paint : function( rafValue ) {


### PR DESCRIPTION
Hi Ibon,

The new debug panel is great. Much better to read and good idea to fix it at the bottom. What I did not like was that it requires the developer to create markup. 
I changed the debug panel to autocreate the markup and styles and inject them into the document. This way it works out of the box.
I also added minimizing and maximizing functionality to save screen space (when debugging mobile games) and short information in the header when the debug panel is minimized. 

Let me know what you think. 

Rob
