### PR TITLE
Automatic Canvas creation bug fix

### DIFF
--- a/src/model/director.js
+++ b/src/model/director.js
@@ -262,7 +262,10 @@
          * @return this
          */
         initialize : function(width, height, canvas, proxy) {
-            canvas = canvas || document.createElement('canvas');
+            if ( !canvas ) {
+              canvas= document.createElement('canvas');
+              document.body.appendChild(canvas);
+            }
             this.canvas = canvas;
 
             if ( typeof proxy==='undefined' ) {


### PR DESCRIPTION
If not sending a Canvas object to `initialize`, a new canvas was being created, but wasn't getting added to the document.
