### PR TITLE
Actor CSS: Fixed bug causing zIndex not to be set in mozilla firefox

### DIFF
--- a/src/model/actorCSS.js
+++ b/src/model/actorCSS.js
@@ -2097,7 +2097,7 @@
                 }
 
                 for( var i=0,l=cl.length; i<l; i++ ) {
-                    cl[i].domElement.style['z-index']= i;
+                    cl[i].domElement.style.zIndex = i;
                 }
             }
         }


### PR DESCRIPTION
Hi there!
Getting you two quick bugfixes as a start!
