### PR TITLE
Behavior bug: Throws error when adding other listeners than behaviorExpired

### DIFF
--- a/src/behaviour/behaviour.js
+++ b/src/behaviour/behaviour.js
@@ -300,7 +300,9 @@
          */
 		fireBehaviorExpiredEvent : function(actor,time)	{
 			for( var i=0; i<this.lifecycleListenerList.length; i++ )	{
-				this.lifecycleListenerList[i].behaviorExpired(this,time,actor);
+          if(this.lifecycleListenerList[i].behaviorExpired) {
+             this.lifecycleListenerList[i].behaviorExpired(this,time,actor);
+          }
 			}
 		},
         /**


### PR DESCRIPTION
To reproduce: 
v = new CAAT.Behavior();
v.addListener({ behaviorStart: function() { console.log("hell yeah") });

because no behaviorExpired is available, an error will be thrown when the behavior expires

patch fixes this :)
