### PR TITLE
clipping path linear path segments

### DIFF
--- a/src/path/path.js
+++ b/src/path/path.js
@@ -199,7 +199,7 @@
 		newPosition:		null,   // spare holder for getPosition coordinate return.
 
         applyAsPath : function(director) {
-            director.ctx.lineTo( this.points[0].x, this.points[1].y );
+            director.ctx.lineTo( this.points[1].x, this.points[1].y );
         },
         setPoint : function( point, index ) {
             if ( index===0 ) {


### PR DESCRIPTION
linear paths didn't work as clipping path for actors, the start x was
used instead of end x
