### PR TITLE
Documentation for x,y

### DIFF
--- a/documentation/tutorials/02_CAAT_Foundation_Actor_Events.html
+++ b/documentation/tutorials/02_CAAT_Foundation_Actor_Events.html
@@ -115,7 +115,7 @@
         the following information:</p>
     <ul>
         <li><b>screenPoint</b><br>The 2D point of the screen coordinate that originated the mouse event.</li>
-        <li><b>x,y</b> the same as screenPoint but w/o being wrapped in an object.</li>
+        <li><b>x,y</b> the same as point but w/o being wrapped in an object.</li>
         <li><b>point</b><br>The 2D point of local Actor coordinates. Remember that local coordinates are from (0,0) to
             actor's
             (width,height). These 2D point is derived from the screenPoint.


### PR DESCRIPTION
Let me know if I'm missing something, but e.screenPoint.x and e.x do not seem to be the same, but e.point.x and e.x seem to be the same.
