### PR TITLE
Fixed removeBehaviour() in Actor.js

### DIFF
--- a/src/Foundation/Actor.js
+++ b/src/Foundation/Actor.js
@@ -1462,14 +1462,15 @@ CAAT.Module({
              *
              * @param behavior {CAAT.Behavior.BaseBehavior}
              */
-            removeBehaviour:function (behavior) {
+            removeBehavior:function (behavior) {
                 var c = this.behaviorList;
                 var n = c.length - 1;
-                while (n) {
+                while (n >= 0) {
                     if (c[n] === behavior) {
                         c.splice(n, 1);
                         return this;
                     }
+                    n = n - 1;
                 }
                 return this;
             },


### PR DESCRIPTION
Previously, the loop only checked one value of n. Added decremement, and escape condition. Without these, function was prone to loop forever.

Also renamed function, as British spelling of "behaviour" (with a 'u') not consistent with usage through the rest of the CAAT code-base.
