### PR TITLE
Fixing WebGL

### DIFF
--- a/src/Foundation/Actor.js
+++ b/src/Foundation/Actor.js
@@ -2317,7 +2317,7 @@ CAAT.Module({
             glSetShader:function (director) {
 
                 var tp = this.getTextureGLPage();
-                if (tp !== director.currentTexturePage) {
+                if (tp && tp !== director.currentTexturePage) {
                     director.setGLTexturePage(tp);
                 }
 

--- a/src/Foundation/Director.js
+++ b/src/Foundation/Director.js
@@ -516,7 +516,12 @@ CAAT.Module({
 
                 this.canvas.width = this.referenceWidth * factor;
                 this.canvas.height = this.referenceHeight * factor;
-                this.ctx = this.canvas.getContext(this.glEnabled ? 'experimental-webgl' : '2d');
+                if (this.glEnabled) {
+                    this.ctx = this.canvas.getContext('webgl') || this.canvas.getContext('experimental-webgl');
+                }
+                else {
+                    this.ctx = this.canvas.getContext('2d');
+                }
 
                 this.__setupRetina();
 
@@ -620,7 +625,12 @@ CAAT.Module({
                     this.canvas.height = h;
                 }
 
-                this.ctx = this.canvas.getContext(this.glEnabled ? 'experimental-webgl' : '2d');
+                if (this.gl) {
+                    this.ctx = this.canvas.getContext('webgl') || this.canvas.getContext('experimental-webgl');
+                }
+                else {
+                    this.ctx = this.canvas.getContext('2d');
+                }
 
                 this.__setupRetina();
 
@@ -718,7 +728,7 @@ CAAT.Module({
                 var i;
 
                 try {
-                    this.gl = canvas.getContext("experimental-webgl"/*, {antialias: false}*/);
+                    this.gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
                     this.gl.viewportWidth = width;
                     this.gl.viewportHeight = height;
                     CAAT.GLRENDER = true;
@@ -759,6 +769,7 @@ CAAT.Module({
                     this.checkDebug();
                 } else {
                     // fallback to non gl enabled canvas.
+                    CAAT.log("WebGL not supported, falling back to 2D canvas.")
                     return this.initialize(width, height, canvas);
                 }
 
@@ -1443,7 +1454,7 @@ CAAT.Module({
                 var ssin = this.scenes[ inSceneIndex ];
                 var sout = this.scenes[ outSceneIndex ];
 
-                if (!CAAT.__CSS__ && CAAT.CACHE_SCENE_ON_CHANGE) {
+                if (!CAAT.__CSS__ && !this.glEnabled && CAAT.CACHE_SCENE_ON_CHANGE) {
                     this.renderToContext(this.transitionScene.ctx, sout);
                     sout = this.transitionScene;
                 }

--- a/src/Foundation/SpriteImage.js
+++ b/src/Foundation/SpriteImage.js
@@ -323,7 +323,7 @@ CAAT.Module({
             initialize:function (image, rows, columns) {
 
                 if (!image) {
-                    console.log("Null image for SpriteImage.");
+                    CAAT.log("Error: got null instead of image object.");
                 }
 
                 if ( isString(image) ) {

--- a/src/Modules/TexturePacker/TexturePage.js
+++ b/src/Modules/TexturePacker/TexturePage.js
@@ -284,8 +284,8 @@ CAAT.Module( {
                 img.__h= newHeight;
 
                 this.scan.substract(where.x,where.y,w,h);
-            } else {
-                CAAT.log('Imagen ',img.src,' de tamano ',img.width,img.height,' no cabe.');
+//            } else {
+//                CAAT.log('Image ',img.src,' of size ',img.width,img.height,' does not fit into texture page.');
             }
         },
         changeHeuristic : function(criteria) {

--- a/src/WebGL/ColorProgram.js
+++ b/src/WebGL/ColorProgram.js
@@ -102,7 +102,7 @@ CAAT.Module( {
 
             this.gl.vertexAttribPointer(
                     this.shaderProgram.vertexColorAttribute,
-                    this.colorBuffer,
+                    4,
                     this.gl.FLOAT,
                     false,
                     0,

--- a/src/WebGL/Program.js
+++ b/src/WebGL/Program.js
@@ -122,6 +122,7 @@ CAAT.Module( {
             return this;
         },
         setMatrixUniform : function( caatMatrix4 ) {
+            this.gl.useProgram(this.shaderProgram);
             this.gl.uniformMatrix4fv(
                     this.shaderProgram.pMatrixUniform,
                     false,


### PR DESCRIPTION
Initialize proper context in case of webgl throughout caat.
Fixes the following errors:
  WebGL: INVALID_VALUE: vertexAttribPointer: bad size, stride or offset
  WebGL: INVALID_OPERATION: uniformMatrix4fv: location is not from current program

This is work in progress and still has some issues. It is still unclear how dynamically rendered textures via a 2d canvas can be included in webgl.
