### PR TITLE
Fixed sprite image index copy in getRef()

### DIFF
--- a/src/Foundation/SpriteImage.js
+++ b/src/Foundation/SpriteImage.js
@@ -285,6 +285,8 @@ CAAT.Module({
 
                 ret.scaleFont= this.scaleFont;
 
+                ret.spriteIndex= this.spriteIndex;
+
                 return ret;
             },
             /**


### PR DESCRIPTION
We're using sprite maps with CAAT: on startup, we load a 2048x2048px map with the preloader and initialize it using the initializeFromMap function. Works like a charm.

In order to use the sprites of the map, we would need to do something along these lines:

  var sprite = spriteMap.getRef().setSpriteIndex('name');
  var actor = new CAAT.Actor();
  actor.setBackgroundImage(sprite, false);
  actor.setSize(sprite.getWidth(), sprite.getHeight());

This is obviously quite uncomfortable. Preferably, one would use something like this:

  var actor = new CAAT.Actor();
  actor.setBackgroundImage(spriteMap.setSpriteIndex('name'), true);

Unfortunately, this does not work because setBackgroundImage calls getRef(), which does not copy the spriteIndex of the image.

We fixed this by copying the spriteIndex in getRef() as well. We can now use the spritemap as describe above, which is really efficient. 
