### PR TITLE
Fix set location body actor

### DIFF
--- a/src/Foundation/Box2D/B2DBodyActor.js
+++ b/src/Foundation/Box2D/B2DBodyActor.js
@@ -181,6 +181,7 @@ CAAT.Module({
                     new Box2D.Common.Math.b2Vec2(
                         x / CAAT.PMR,
                         y / CAAT.PMR));
+
                 return this;
             },
 


### PR DESCRIPTION
Calling setPosition on a body actor does not set the x and y attribute of that actor. It's usually set later (during the physics loop I guess), but until that moment x and y remain undefined.

Re-done unclean pull request.
See https://github.com/hyperandroid/CAAT/issues/121
