### PR TITLE
Added a standard constant for keyframes rules

### DIFF
--- a/src/Modules/CSS/csskeyframehelper.js
+++ b/src/Modules/CSS/csskeyframehelper.js
@@ -132,7 +132,8 @@
                          [];
 
                 for (var j = rs.length - 1; j >= 0; j--) {
-                    if ( ( rs[j].type === window.CSSRule.WEBKIT_KEYFRAMES_RULE ||
+                    if ( ( rs[j].type === window.CSSRule.KEYFRAMES_RULE ||
+                           rs[j].type === window.CSSRule.WEBKIT_KEYFRAMES_RULE ||
                            rs[j].type === window.CSSRule.MOZ_KEYFRAMES_RULE ) && rs[j].name === name) {
 
                         return {
@@ -159,7 +160,8 @@
                          [];
 
                 for (var j = rs.length - 1; j >= 0; j--) {
-                    if ( ( rs[j].type === window.CSSRule.WEBKIT_KEYFRAMES_RULE ||
+                    if ( ( rs[j].type === window.CSSRule.KEYFRAMES_RULE ||
+                           rs[j].type === window.CSSRule.WEBKIT_KEYFRAMES_RULE ||
                            rs[j].type === window.CSSRule.MOZ_KEYFRAMES_RULE ) && rs[j].name === name) {
 
                         return rs[j];


### PR DESCRIPTION
The code was only looking for prefixed constants, but the standard constant is supported by all of the browsers for quite some time.

I would even go farther and remove those constants (and the prefix-querying code at the top) completely, but there might be old version support level for this library.